### PR TITLE
feat: use `GetByIDS` for secret fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ bin/
 dist/
 hack/cert-manager.yaml
 hack/rootCA.pem
+
+# Bitwarden state file
+.bitwarden-state

--- a/README.md
+++ b/README.md
@@ -35,6 +35,46 @@ Response:
 }
 ```
 
+### GetSecretsByIds
+
+`/rest/api/1/secrets-by-ids`
+
+Method `GET`.
+
+```json
+{
+  "ids": [
+    "f5847eef-2f89-43bc-885a-b18a01178e3e", "0cab75c4-ba26-4996-a8bf-517095857ce3"
+  ]
+}
+```
+
+Response:
+```json
+{
+  "data": [
+    {
+      "creationDate": "2024-04-04",
+      "id": "f5847eef-2f89-43bc-885a-b18a01178e3e",
+      "key": "test",
+      "note": "note",
+      "organizationId": "f5847eef-2f89-43bc-885a-b18a01178e3e",
+      "revisionDate": "2024-04-04",
+      "value": "value"
+    },
+    {
+      "creationDate": "2024-04-05",
+      "id": "0cab75c4-ba26-4996-a8bf-517095857ce3",
+      "key": "test2",
+      "note": "note2",
+      "organizationId": "f5847eef-2f89-43bc-885a-b18a01178e3e",
+      "revisionDate": "2024-04-05",
+      "value": "value2"
+    }
+  ]
+}
+```
+
 ### ListSecrets
 
 `/rest/api/1/secrets`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,6 +70,7 @@ func (s *Server) Run(_ context.Context) error {
 	// The header will always contain the right credentials.
 	warden.Get("/secret", s.getSecretHandler)
 	warden.Get("/secrets", s.listSecretsHandler)
+	warden.Get("/secrets-by-ids", s.getByIdsSecretHandler)
 	warden.Delete("/secret", s.deleteSecretHandler)
 	warden.Post("/secret", s.createSecretHandler)
 	warden.Put("/secret", s.updateSecretHandler)
@@ -104,6 +105,26 @@ func (s *Server) getSecretHandler(w http.ResponseWriter, r *http.Request) {
 	secretResponse, err := c.Secrets().Get(request.ID)
 	if err != nil {
 		http.Error(w, "failed to get secret: "+err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	s.handleResponse(secretResponse, w)
+}
+
+func (s *Server) getByIdsSecretHandler(w http.ResponseWriter, r *http.Request) {
+	request := &sdk.SecretsGetRequest{}
+	c, err := s.getClient(r, &request)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+	defer c.Close()
+
+	secretResponse, err := c.Secrets().GetByIDS(request.IDS)
+	if err != nil {
+		http.Error(w, "failed to get secrets: "+err.Error(), http.StatusBadRequest)
 
 		return
 	}


### PR DESCRIPTION
## Problem Statement

Using the `Secrets().Get()` method makes individual requests to the Bitwarden API for each secret. This increases load on the server and makes it more likely that rate-limiting occurs.

## Related Issue

Fixes #...

## Proposed Changes

Use the `Secrets.GetByIDS()` method, which accepts multiple secret IDs and can return the secret data for multiple secrets with a single API request, and therefore reduce the potential for rate-limiting for the Bitwarden server.

This implementation adds a `secrets-by-ids` endpoint to avoid introducing any breaking changes to the operator. Ideally, using `Secrets().GetByIDS()` could become the default for the `/rest/api/1/secrets` or `/rest/api/1/secret` endpoint, but this would likely break the current usage of the operator.

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
