### PR TITLE
Update Chart.yaml

### DIFF
--- a/deploy/charts/bitwarden-sdk-server/Chart.yaml
+++ b/deploy/charts/bitwarden-sdk-server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "v0.3.1"


### PR DESCRIPTION
Set appVersion to Current Release

## Problem Statement

Helm Deployment not working out of the Box. When i deploy the Helm Chart seperately from External Secrets Operator with the enabeled Option


## Related Issue

Fixes #...

## Proposed Changes

I fixed the Version, i am unsure if Renovate will pickit up properly

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
