### PR TITLE
fix: certificate was not built correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ WORKDIR /workspace
 COPY . .
 RUN mkdir state
 RUN apt update && apt install unzip musl-tools ca-certificates -y
+RUN update-ca-certificates
 RUN make build-docker
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-# RUN apt-get update && apt-get install -y ca-certificates
-COPY --from=build /etc/ssl/certs /etc/ssl/certs
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /workspace/bin/bitwarden-sdk-server .
 COPY --from=build --chown=65532:65532 /workspace/state/ ./state/
 

--- a/tilt.dockerfile
+++ b/tilt.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782
+FROM alpine@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
 WORKDIR /
 COPY ./bin/bitwarden-sdk-server /bitwarden-sdk-server
 


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes https://github.com/external-secrets/external-secrets/issues/4824

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`
