### PR TITLE
Namespace setting via helm

### DIFF
--- a/deploy/charts/bitwarden-sdk-server/templates/_helpers.tpl
+++ b/deploy/charts/bitwarden-sdk-server/templates/_helpers.tpl
@@ -24,6 +24,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Define the namespace of the chart.
+*/}}
+{{- define "bitwarden-sdk-server.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "bitwarden-sdk-server.chart" -}}

--- a/deploy/charts/bitwarden-sdk-server/templates/deployment.yaml
+++ b/deploy/charts/bitwarden-sdk-server/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "bitwarden-sdk-server.fullname" . }}
+  namespace: {{ template "bitwarden-sdk-server.namespace" . }}
   labels:
     {{- include "bitwarden-sdk-server.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/bitwarden-sdk-server/templates/service.yaml
+++ b/deploy/charts/bitwarden-sdk-server/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "bitwarden-sdk-server.fullname" . }}
+  namespace: {{ template "bitwarden-sdk-server.namespace" . }}
   labels:
     {{- include "bitwarden-sdk-server.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/bitwarden-sdk-server/templates/serviceaccount.yaml
+++ b/deploy/charts/bitwarden-sdk-server/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "bitwarden-sdk-server.serviceAccountName" . }}
+  namespace: {{ template "bitwarden-sdk-server.namespace" . }}
   labels:
     {{- include "bitwarden-sdk-server.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/deploy/charts/bitwarden-sdk-server/tests/__snapshot__/deployment_test.yaml.snap
+++ b/deploy/charts/bitwarden-sdk-server/tests/__snapshot__/deployment_test.yaml.snap
@@ -10,6 +10,7 @@ deployment should match snapshot:
         app.kubernetes.io/version: 1.16.0
         helm.sh/chart: bitwarden-sdk-server-0.1.0
       name: bitwarden-sdk-server
+      namespace: NAMESPACE
     spec:
       replicas: 1
       selector:

--- a/deploy/charts/bitwarden-sdk-server/values.yaml
+++ b/deploy/charts/bitwarden-sdk-server/values.yaml
@@ -29,6 +29,7 @@ image:
 imagePullSecrets: []
 nameOverride: "bitwarden-sdk-server"
 fullnameOverride: "bitwarden-sdk-server"
+namespaceOverride: ""
 
 # Use this to set Environment Variables e.g. HTTP_PROXY, HTTPS_PROXY
 extraEnv: {}


### PR DESCRIPTION
## Problem Statement

Release was deployed on default namespace, without the option to configure this via helm.

## Related Issue

No related issue

## Proposed Changes

Add helper and value to helm chart for templating

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
