### PR TITLE
refactor: allow override of tls secret name

### DIFF
--- a/deploy/charts/bitwarden-sdk-server/templates/deployment.yaml
+++ b/deploy/charts/bitwarden-sdk-server/templates/deployment.yaml
@@ -53,8 +53,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.tls.enabled }}
           volumeMounts:
+          {{- if .Values.image.tls.volumeMounts }}
+          {{- toYaml .Values.image.tls.volumeMounts | nindent 12 }}
+          {{- else }}
             - mountPath: /certs
-              name: {{ .Values.image.tls.secret }}
+              name: {{ .Values.image.tls.secretName }}
+          {{- end}}
           {{- end}}
           ports:
             - name: http
@@ -90,9 +94,12 @@ spec:
       {{- end }}
       {{- if .Values.image.tls.enabled }}
       volumes:
-        - name: {{ .Values.image.tls.secret }}
+      {{- if .Values.image.tls.volumes }}
+      {{- toYaml .Values.image.tls.volumes | nindent 8 }}
+      {{- else }}
+        - name: {{ .Values.image.tls.secretName }}
           secret:
-            secretName: {{ .Values.image.tls.secret }}
+            secretName: {{ .Values.image.tls.secretName }}
             items:
               - key: tls.crt
                 path: cert.pem
@@ -100,4 +107,5 @@ spec:
                 path: key.pem
               - key: ca.crt
                 path: ca.pem
+      {{- end}}
       {{- end}}

--- a/deploy/charts/bitwarden-sdk-server/values.yaml
+++ b/deploy/charts/bitwarden-sdk-server/values.yaml
@@ -11,8 +11,12 @@ image:
   tag: ""
   tls:
     enabled: true
-    # Name of the secret that contains the TLS cert
-    secret: bitwarden-tls-certs
+    # Name of the secret that contains the TLS cert. Ignored when `image.tls.volumes` is set
+    secretName: bitwarden-tls-certs
+    # Use this to override the default volumes
+    volumes: []
+    # Use this to override the default volume mounts
+    volumeMounts: []
 
 imagePullSecrets: []
 nameOverride: "bitwarden-sdk-server"


### PR DESCRIPTION
## Problem Statement

Make the certificate secret name configurable, without having to override the whole `image.tls.volumes` and `image.tls.volumeMounts` arrays.

## Related Issue

Fixes #55

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [x] All tests pass with `make test`
- [x] I ensured my PR is ready for review with `make reviewable`
