### PR TITLE
fix: close the client after the warden is done because ServeHTTP is a blocking call

### DIFF
--- a/pkg/bitwarden/bitwarden.go
+++ b/pkg/bitwarden/bitwarden.go
@@ -125,6 +125,7 @@ func Warden(next http.Handler) http.Handler {
 
 			return
 		}
+		defer client.Close()
 
 		ctx := context.WithValue(r.Context(), ContextClientKey, client)
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,7 +100,6 @@ func (s *Server) getSecretHandler(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	defer c.Close()
 
 	secretResponse, err := c.Secrets().Get(request.ID)
 	if err != nil {
@@ -120,7 +119,6 @@ func (s *Server) getByIdsSecretHandler(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	defer c.Close()
 
 	secretResponse, err := c.Secrets().GetByIDS(request.IDS)
 	if err != nil {
@@ -140,7 +138,6 @@ func (s *Server) listSecretsHandler(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	defer c.Close()
 
 	secretResponse, err := c.Secrets().List(request.OrganizationID)
 	if err != nil {
@@ -160,7 +157,6 @@ func (s *Server) deleteSecretHandler(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	defer c.Close()
 
 	response, err := c.Secrets().Delete(request.IDS)
 	if err != nil {
@@ -180,7 +176,6 @@ func (s *Server) createSecretHandler(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	defer c.Close()
 
 	response, err := c.Secrets().Create(request.Key, request.Value, request.Note, request.OrganizationID, request.ProjectIDS)
 	if err != nil {
@@ -200,7 +195,6 @@ func (s *Server) updateSecretHandler(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	defer c.Close()
 
 	response, err := c.Secrets().Update(request.ID, request.Key, request.Value, request.Note, request.OrganizationID, request.ProjectIDS)
 	if err != nil {


### PR DESCRIPTION
## Problem Statement

In case of errors the client constructed by the Warden is actually never closed properly. So we defer close it in the Login since Next is a blocking call, this should be okay.

## Related Issue

Fixes https://github.com/external-secrets/bitwarden-sdk-server/issues/65

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix memory leak in Bitwarden client lifecycle

**Problem**: The Bitwarden client created during login was never closed, causing memory to grow indefinitely with each request.

**Solution**: Move client cleanup from individual request handlers to the login middleware by:
- Adding `defer client.Close()` in the Warden middleware after successful client creation
- Removing six redundant `defer c.Close()` calls from individual handlers (getSecretHandler, getByIdsSecretHandler, listSecretsHandler, deleteSecretHandler, createSecretHandler, updateSecretHandler)

This ensures the client is properly closed after all downstream handlers complete, with the middleware-level defer being acceptable since ServeHTTP/Next is a blocking call.

**Changes**: 
- `pkg/bitwarden/bitwarden.go`: +1 line (added defer)
- `pkg/server/server.go`: -6 lines (removed redundant defers)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->