### PR TITLE
feat: Allow users to configure labels

### DIFF
--- a/deploy/charts/bitwarden-sdk-server/templates/_helpers.tpl
+++ b/deploy/charts/bitwarden-sdk-server/templates/_helpers.tpl
@@ -51,6 +51,9 @@ helm.sh/chart: {{ include "bitwarden-sdk-server.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/deploy/charts/bitwarden-sdk-server/templates/deployment.yaml
+++ b/deploy/charts/bitwarden-sdk-server/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "bitwarden-sdk-server.labels" . | nindent 4 }}
+    {{- with .Values.deploymentLabels }}
+    {{- toYaml .  | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -22,6 +25,9 @@ spec:
       {{- end }}
       labels:
         {{- include "bitwarden-sdk-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/charts/bitwarden-sdk-server/templates/service.yaml
+++ b/deploy/charts/bitwarden-sdk-server/templates/service.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: {{ template "bitwarden-sdk-server.namespace" . }}
   labels:
     {{- include "bitwarden-sdk-server.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml .  | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/charts/bitwarden-sdk-server/templates/serviceaccount.yaml
+++ b/deploy/charts/bitwarden-sdk-server/templates/serviceaccount.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ template "bitwarden-sdk-server.namespace" . }}
   labels:
     {{- include "bitwarden-sdk-server.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml .  | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/charts/bitwarden-sdk-server/values.yaml
+++ b/deploy/charts/bitwarden-sdk-server/values.yaml
@@ -28,9 +28,14 @@ extraEnv: {}
   # - name: HTTP_PROXY
   #   value: "http://example.com:8080/"
 
+# Additional labels to add to all chart resources
+commonLabels: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Labels to add to the service account
+  labels: {}
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -50,6 +55,9 @@ podDnsConfig: {}
   #     value: "2"
   #   - name: edns0
 
+podLabels: {}
+deploymentLabels: {}
+
 podAnnotations: {}
 deploymentAnnotations: {}
 
@@ -67,6 +75,10 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 9998
+  # Labels to add to the service
+  labels: {}
+  # Annotations to add to the service
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Problem Statement
Chart lacks a way to configure labels

## Related Issue

#71 

## Proposed Changes

Allow configuring labels for deployed resources

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [x] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds support for configuring labels and annotations across Helm chart resources. Updates include:

- **values.yaml**: Introduces new configuration options for `commonLabels`, `serviceAccount.labels`, `podLabels`, `deploymentLabels`, `podAnnotations`, `deploymentAnnotations`, `service.labels`, and `service.annotations`
- **_helpers.tpl**: Adds conditional rendering of `commonLabels` in the bitwarden-sdk-server.labels template
- **deployment.yaml**: Adds conditional rendering of `deploymentLabels` and `podLabels`
- **service.yaml**: Adds conditional rendering of `service.labels` and `service.annotations`
- **serviceaccount.yaml**: Adds conditional rendering of `serviceAccount.labels`

All changes are backward compatible and only apply when the corresponding values are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->