### PR TITLE
fix: replace bitwarden sdk with memory leak fix fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,10 @@ module github.com/external-secrets/bitwarden-sdk-server
 
 go 1.22
 
+replace github.com/bitwarden/sdk-go/v2 => github.com/Skarlso/sdk-go/v2 v2.0.0
+
 require (
-	github.com/bitwarden/sdk-go v1.0.2
+	github.com/bitwarden/sdk-go/v2 v2.0.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,12 @@
-github.com/bitwarden/sdk-go v1.0.2 h1:krk5et4sfksLDDcrYHcs8f3jL/TGcQ1EShw4CG21JSI=
-github.com/bitwarden/sdk-go v1.0.2/go.mod h1:RuYh+gqffp3h8wNUVWz1bvp2Pho10AFz+WIlI26iWY4=
+github.com/Skarlso/sdk-go/v2 v2.0.0 h1:6j9YeHxWm+AwIEEhXQ6LbrwYuUJlMvVv3zPu8H1r2kQ=
+github.com/Skarlso/sdk-go/v2 v2.0.0/go.mod h1:6Sfb4IdZ9tnggeFj8Ty4MLkWUyC2pNlFUoAZE0Dapfw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
+github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/bitwarden/bitwarden.go
+++ b/pkg/bitwarden/bitwarden.go
@@ -20,7 +20,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/bitwarden/sdk-go"
+	"github.com/bitwarden/sdk-go/v2"
 )
 
 type contextKey string

--- a/pkg/bitwarden/bitwarden_test.go
+++ b/pkg/bitwarden/bitwarden_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/bitwarden/sdk-go"
+	"github.com/bitwarden/sdk-go/v2"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bitwarden/sdk-go"
+	"github.com/bitwarden/sdk-go/v2"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitwarden/sdk-go"
+	"github.com/bitwarden/sdk-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR replaces the Bitwarden Go SDK dependency with a fork that includes a memory-leak fix.

### Dependency Updates
- **go.mod**: Adds a `replace` directive to use `github.com/Skarlso/sdk-go/v2 v2.0.0` instead of the official `github.com/bitwarden/sdk-go`, and updates the required version from v1.0.2 to v2.0.0.

### Import Path Updates
- Updated import paths in four files to use the v2 API (`github.com/bitwarden/sdk-go/v2`):
  - `pkg/bitwarden/bitwarden.go`
  - `pkg/bitwarden/bitwarden_test.go`
  - `pkg/server/server.go`
  - `pkg/server/server_test.go`

No functional logic changes; all modifications are limited to dependency and import path updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->