### PR TITLE
Add priority class name configuration to deployment

### DIFF
--- a/deploy/charts/bitwarden-sdk-server/templates/deployment.yaml
+++ b/deploy/charts/bitwarden-sdk-server/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "bitwarden-sdk-server.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.podDnsPolicy }}

--- a/deploy/charts/bitwarden-sdk-server/tests/deployment_test.yaml
+++ b/deploy/charts/bitwarden-sdk-server/tests/deployment_test.yaml
@@ -27,3 +27,14 @@ tests:
       - equal:
           path: spec.template.spec.dnsConfig.options[0].value
           value: "2"
+  - it: Should not have Priority Class Name set by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+  - it: Should have Priority Class Name set when configured
+    set:
+      priorityClassName: "system-cluster-critical"
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: "system-cluster-critical"

--- a/deploy/charts/bitwarden-sdk-server/values.yaml
+++ b/deploy/charts/bitwarden-sdk-server/values.yaml
@@ -60,6 +60,7 @@ deploymentLabels: {}
 
 podAnnotations: {}
 deploymentAnnotations: {}
+priorityClassName: ""
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

The priorityClassName is not configurable in the helm chart

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

adding the priorityClassName value to the deplyoment and values. Keept empty to not break or change active

## Checklist

- [X] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [X] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage
- [~] All tests pass with `make test` -> just `helm unittest .`
- [X] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds `priorityClassName` as a configurable value for the Kubernetes Deployment in the Helm chart. The feature is optional with an empty default value to preserve backward compatibility.

## Changes

**Helm Chart Configuration:**
- `values.yaml`: Added `priorityClassName` configuration parameter with empty default
- `templates/deployment.yaml`: Added conditional rendering of `priorityClassName` in the pod spec when configured

**Tests:**
- `tests/deployment_test.yaml`: Added test cases verifying that `priorityClassName` is absent by default and correctly set when configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->