### PR TITLE
chore: adding release notes v0.6.0

### DIFF
--- a/docs/release_notes/v0.6.0.md
+++ b/docs/release_notes/v0.6.0.md
@@ -1,0 +1,9 @@
+## What's Changed
+* chore(deps): bump github.com/go-chi/chi/v5 from 5.2.4 to 5.2.5 in the go group by @dependabot[bot] in https://github.com/external-secrets/bitwarden-sdk-server/pull/69
+* feat: Allow users to configure labels by @brookelew in https://github.com/external-secrets/bitwarden-sdk-server/pull/72
+* fix: replace bitwarden sdk with memory leak fix fork by @Skarlso in https://github.com/external-secrets/bitwarden-sdk-server/pull/73
+
+## New Contributors
+* @brookelew made their first contribution in https://github.com/external-secrets/bitwarden-sdk-server/pull/72
+
+**Full Changelog**: https://github.com/external-secrets/bitwarden-sdk-server/compare/v0.5.3...v0.6.0


### PR DESCRIPTION
Signed-off-by: Gergely Brautigam <182850+Skarlso@users.noreply.github.com>

On-behalf-of: Gergely Brautigam <gergely.brautigam@sap.com>

## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test`
- [ ] I ensured my PR is ready for review with `make reviewable`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds release notes for v0.6.0 documenting three main items: a dependencies bump for github.com/go-chi/chi/v5 (5.2.4 to 5.2.5), a new feature for configurable labels, and a fix reverting to the memory-leak-fix fork of the Bitwarden SDK. Also notes @brookelew as a new contributor and includes a link to the full v0.5.3 to v0.6.0 changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->