### PR TITLE
docs: add missing devguide.md + process.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,4 @@ How do you like to solve the issue and why?
 - [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
 - [ ] All commits are signed with `git commit --signoff`
 - [ ] My changes have reasonable test coverage
-- [ ] All tests pass with `make test`
-- [ ] I ensured my PR is ready for review with `make reviewable`
+- [ ] All tests pass with `make test-ci`

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ hack/rootCA.pem
 
 # Bitwarden state file
 .bitwarden-state
+
+# delve debug files
+__debug_*

--- a/docs/contributing/devguide.md
+++ b/docs/contributing/devguide.md
@@ -24,3 +24,13 @@ break funcs listSecretsHandler
 # and start code execution
 continue
 ````
+
+## Unit Tests
+
+````bash
+# run test suite
+make test-ci
+
+# if you're on mac run
+CGO_LDFLAGS="-framework CoreFoundation" CGO_ENABLED=1 go test ./... -coverprofile cover.out
+````

--- a/docs/contributing/devguide.md
+++ b/docs/contributing/devguide.md
@@ -1,0 +1,26 @@
+## Local Setup
+
+How to run this repo locally (after cloning):
+
+* First [install a recent version of go](https://go.dev/doc/install) (see [go.mod](../../go.mod) for the minimum version).
+
+* Then run the following:
+
+````bash
+cd bitwarden-sdk-server/
+
+# install go dependencies
+go mod tidy
+
+# launch server
+go run main.go serve --insecure --hostname :9998 --debug
+
+# alternatively you can launch the server with the delve debugger:
+go install github.com/go-delve/delve/cmd/dlv@v1.26.1
+
+dlv debug main.go -- serve --insecure --hostname :9998 --debug
+# optionally set a breakpoint at a given function
+break funcs listSecretsHandler
+# and start code execution
+continue
+````

--- a/docs/contributing/process.md
+++ b/docs/contributing/process.md
@@ -1,0 +1,37 @@
+## Project Management
+The Code, our TODOs and Documentation is maintained on
+[GitHub](https://github.com/external-secrets/bitwarden-sdk-server). All Issues
+should be opened in that repository.
+
+## Issues
+
+Features, bugs and any issues regarding the documentation should be filed as
+[GitHub Issue](https://github.com/external-secrets/bitwarden-sdk-server/issues) in
+our repository. We use labels like `kind/feature`, `kind/bug`, `area/aws` to
+organize the issues. Issues labeled `good first issue` and `help wanted` are
+especially good for a first contribution. If you want to pick up an issue just
+leave a comment.
+
+## Submitting a Pull Request
+
+This project uses the well-known pull request process from GitHub. To submit a
+pull request, fork the repository and push any changes to a branch on the copy,
+from there a pull request can be made in the main repo. Merging a pull request
+requires the following steps to be completed before the pull request will
+be merged:
+
+* ideally, there is an issue that documents the problem or feature in depth.
+* code must have a reasonable amount of test coverage
+* tests must pass
+* PR needs be reviewed and approved
+
+Once these steps are completed the PR will be merged by a code owner.
+We're using the pull request `assignee` feature to track who is responsible
+for the lifecycle of the PR: review, merging, ping on inactivity, close.
+We close pull requests or issues if there is no response from the author for
+a period of time. Feel free to reopen if you want to get back on it.
+
+_Note:_
+Pull requests that are labelled with _size/l_ and above _MUST_ have at least **TWO**
+approvers for it to be merged. Please respect this policy to ensure the quality
+of code in this project.


### PR DESCRIPTION
## Problem Statement

Improve docs, fixing broken links.

## Related Issue

Fixes https://github.com/external-secrets/bitwarden-sdk-server/issues/78

## Proposed Changes

I copied part of the process.md from the external-secrets/external-secrets repo

## Checklist

- [x] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [x] All commits are signed with `git commit --signoff`
- [X] My changes have reasonable test coverage (N/A)
- [x] All tests pass with ~~make test~~ (`make test-ci`)
- [ ] ~~I ensured my PR is ready for review with `make reviewable`~~ (this doesn't exist)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation additions and gitignore update

This PR adds developer and contribution process documentation and updates ignore patterns.

Files added/changed:
- docs/contributing/devguide.md — Local development instructions: Go install, dependency setup (go mod tidy), server startup (go run main.go serve --insecure --hostname :9998 --debug), optional Delve debug workflow, and test commands (make test-ci; macOS go test variant).
- docs/contributing/process.md — Contribution/process guidance: issue filing, labels, PR workflow, merge checklist, and rule requiring two approvers for PRs labeled _size/l_ and larger.
- .github/pull_request_template.md — Updates PR checklist to require running tests with make test-ci and removes the make reviewable item.
- .gitignore — Adds pattern to ignore Delve debug files (__debug_*).

All changes are documentation/configuration only and do not affect public APIs or exported entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->