### PR TITLE
chore: replace my fork of bitwarden SDK and update go version

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,6 @@ linters:
     - exhaustive
     - copyloopvar
     - goheader
-    - goconst
     - gocritic
     - godot
     - goprintffuncname

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as build
+FROM golang:1.26 AS build
 WORKDIR /workspace
 COPY . .
 RUN mkdir state

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 
 # List the GOOS and GOARCH to build
 GO_LDFLAGS_STATIC="-s -w $(CTIMEVAR) -extldflags -static"
-GOLANGCI_LINT_VERSION ?= v2.11.3
+GOLANGCI_LINT_VERSION ?= v2.12.2
 MKCERT_VERSION ?= v1.4.4
 
 .DEFAULT_GOAL := help
@@ -87,7 +87,7 @@ docker_image: ## Creates a docker image. Requires `image` and `version` variable
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(LOCALBIN)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 
 help:  ## Display this help. Thanks to https://www.thapaliya.com/en/writings/well-documented-makefiles/
 ifeq ($(OS),Windows_NT)

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,9 @@
 module github.com/external-secrets/bitwarden-sdk-server
 
-go 1.23
-
-replace github.com/bitwarden/sdk-go/v2 => github.com/Skarlso/sdk-go/v2 v2.0.0
+go 1.26
 
 require (
-	github.com/bitwarden/sdk-go/v2 v2.0.0
+	github.com/bitwarden/sdk-go/v2 v2.1.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Skarlso/sdk-go/v2 v2.0.0 h1:6j9YeHxWm+AwIEEhXQ6LbrwYuUJlMvVv3zPu8H1r2kQ=
-github.com/Skarlso/sdk-go/v2 v2.0.0/go.mod h1:6Sfb4IdZ9tnggeFj8Ty4MLkWUyC2pNlFUoAZE0Dapfw=
+github.com/bitwarden/sdk-go/v2 v2.1.0 h1:DtgklUXNA3GcP5t1eXEEefd0UY6Gv5041/+gZHD2174=
+github.com/bitwarden/sdk-go/v2 v2.1.0/go.mod h1:6Sfb4IdZ9tnggeFj8Ty4MLkWUyC2pNlFUoAZE0Dapfw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] I have read the [contribution guidelines](https://external-secrets.io/latest/contributing/process/#submitting-a-pull-request)
- [ ] All commits are signed with `git commit --signoff`
- [ ] My changes have reasonable test coverage
- [ ] All tests pass with `make test-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Go version**: Updated from 1.23 to 1.26 across Dockerfile, Makefile, and go.mod
- **Bitwarden SDK**: Removed personal fork reference and upgraded from v2.0.0 to v2.1.0, now using the official `github.com/bitwarden/sdk-go/v2`
- **golangci-lint**: Updated from v2.11.3 to v2.12.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->